### PR TITLE
fix: set dayjs to fixed timezone to fix hydration issue

### DIFF
--- a/app/components/Form/DateTime/useDateTime.ts
+++ b/app/components/Form/DateTime/useDateTime.ts
@@ -1,4 +1,4 @@
-import { applyTimezone, dateObject } from "@/utils/day";
+import { dateObject } from "@/utils/day";
 import { FieldProps, useField } from "informed";
 import { ChangeEventHandler, useCallback, useMemo } from "react";
 
@@ -26,7 +26,7 @@ export const useDateTime = (props: FieldProps<UserProps>) => {
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     (e) => {
-      const parsedDate = applyTimezone(dateObject(e.target.value)).utc()
+      const parsedDate = dateObject(e.target.value).utc()
         .toISOString();
       setValue(parsedDate, e);
     },
@@ -34,7 +34,7 @@ export const useDateTime = (props: FieldProps<UserProps>) => {
   );
 
   const parsedValue = useMemo(() => {
-    const dateTime = applyTimezone(dateObject(value as string)).format(
+    const dateTime = dateObject(value as string).format(
       "YYYY-MM-DDTHH:mm",
     );
     return dateTime;

--- a/app/utils/day.ts
+++ b/app/utils/day.ts
@@ -30,11 +30,7 @@ export const semanticDate = (date: Dayjs) => {
 };
 
 export const dateObject = (dateString: string) => {
-  return dayjs(dateString);
-};
-
-export const applyTimezone = (date: Dayjs, tz = DEFAULT_TIMEZONE) => {
-  return date.tz(tz);
+  return dayjs(dateString).tz(DEFAULT_TIMEZONE);
 };
 
 export const lockDate = (dateString: string) => {

--- a/app/utils/validators.ts
+++ b/app/utils/validators.ts
@@ -1,4 +1,4 @@
-import { applyTimezone, dateObject } from "./day";
+import { dateObject } from "./day";
 
 export const validateLength = (name: string) => {
   if (!name?.length) {
@@ -14,8 +14,7 @@ export const validateSegments = (name: string) => {
 
 export const validateAgainstPastDate = (date: string) => {
   if (
-    applyTimezone(dateObject(date)) <
-      applyTimezone(dateObject(new Date().toISOString()))
+    dateObject(date) < dateObject(new Date().toISOString())
   ) {
     throw new Error("Gewähltes Datum kann nicht in der Vergangenheit liegen.");
   }


### PR DESCRIPTION
This PR fixes hydration issues where the fallback timezone during SSR was that of the server's and thus differed from the user's browser's.