### PR TITLE
fix: fixed output for commit message

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         id: vars
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
-          COMMIT_MESSAGE=$(git log -1 --no-merges --pretty=%B)
+          COMMIT_MESSAGE=$(git log -1 --no-merges --pretty=%s)
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
           echo $SHORT_SHA $COMMIT_MESSAGE


### PR DESCRIPTION
This PR fixes the output for the commit message.
Especially for squashed PRs with multiple commit messages, the workflow failed to extract the commit message needed for the Netlify deployment message.